### PR TITLE
Prepare first release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,185 +30,26 @@ Or install it yourself as:
 - **Create file _config/initializers/shrine.rb_**
 ```ruby
 require 'shrine'
-require 'shrine/storage/redis'
-require 'shrine/storage/file_system'
+require "shrine/storage/azure_blob"
 
-if Rails.env.production?
-  azure_options = {
-    account_name: ENV.fetch('AZURE_ACCOUNT_NAME'),
-    access_key: ENV.fetch('AZURE_ACCESS_KEY'),
-    container_name: ENV.fetch('AZURE_CONTAINER')
-  }
+azure_options = {
+  account_name: ENV.fetch('AZURE_ACCOUNT_NAME'),
+  access_key: ENV.fetch('AZURE_ACCESS_KEY'),
+  container_name: ENV.fetch('AZURE_CONTAINER')
+}
 
-  Shrine.storages = {
-    cache: Shrine::Storage::Redis.new(client: Redis.current, expire: 120),
-    store: Shrine::Storage::AzureBlob.new(**azure_options)
-  }
-else
-  Shrine.storages = {
-    cache: Shrine::Storage::FileSystem.new('public', prefix: 'storage/cache'), # INFO: temporary
-    store: Shrine::Storage::FileSystem.new('public', prefix: 'storage') # INFO: permanent
-  }
-end
-
-# INFO: Best practice default plugins
-Shrine.plugin :activerecord
-Shrine.plugin :cached_attachment_data # INFO: for forms
-Shrine.plugin :restore_cached_data # INFO: re-extract metadata when attaching a cached file
-Shrine.plugin :backgrounding
-Shrine.plugin :logging, logger: Rails.logger unless Rails.env.test?
-
-# INFO: Using for provide uploading process through Sidekiq async BG jobs
-Shrine::Attacher.promote { |data| AttachmentUploadJob.perform_async(data) }
-Shrine::Attacher.delete { |data| AttachmentDeleteJob.perform_async(data) }
+Shrine.storages = {
+  cache: Shrine::Storage::FileSystem.new("tmp", prefix: "uploads/cache"),
+  store: Shrine::Storage::AzureBlob.new(**azure_options)
+}
 ```
-
-- **Add to _config/application.rb_ uploaders dir**
-```ruby
-...
-config.autoload_paths += %w[
-  app/uploaders
-  ...
-].map { |path| Rails.root.join(path).to_s }
-...
-```
-
-- **Example of uploader _app/uploaders/image_uploader.rb_**
-```ruby
-class ImageUploader < Shrine
-  MAX_SIZE = 20
-  plugin :remote_url, max_size: MAX_SIZE * 1024 * 1024
-  plugin :processing # INFO: allows hooking into promoting
-  plugin :validation_helpers
-  plugin :versions   # INFO: enable Shrine to handle a hash of files
-  plugin :remove_invalid # INFO: immediately delete the file if it failed validations
-
-  unless Rails.env.test? # INFO: delete processed && promoted files after uploading
-    plugin :delete_raw
-    plugin :delete_promoted
-  end
-
-  plugin :determine_mime_type, analyzer: lambda { |io, analyzers|
-    mime_type = analyzers[:file].call(io)
-    mime_type = analyzers[:mime_types].call(io) if mime_type == 'text/plain'
-    mime_type
-  }
-
-  opts[:type] = 'image'
-
-  Attacher.validate do
-    validate_max_size MAX_SIZE * 1024 * 1024, message: "is too large (max is #{MAX_SIZE} MB)"
-    validate_mime_type_inclusion %w[image/jpeg image/png image/gif image/bmp]
-  end
-
-  process(:store) do |io, _context|
-    # INFO: versions = {} # { original: io } - retain original
-    versions = { original: io }
-    io.download do |original|
-      pipeline = ImageProcessing::MiniMagick.source(original)
-      versions[:large]  = pipeline.resize_to_limit!(1280, 1280)
-      versions[:medium] = pipeline.resize_to_limit!(640, 640)
-      versions[:small]  = pipeline.resize_to_limit!(200, 200)
-    end
-    versions # INFO: return the hash of processed files
-  end
-end
-```
-
-- **Create DB migration (for polymorphic association use)**
-```ruby
-create_table :attachments, id: :serial, force: :cascade do |t|
-  t.json :file_data
-  t.string :type
-  t.string :file_remote_url
-  t.string :attachable_type
-  t.bigint :attachable_id
-  t.index %i[attachable_type attachable_id]
-end
-```
-
-- **Create AR models**
-```ruby
-# INFO: app/models/attachemnt.rb
-class Attachment < ApplicationRecord
-  include AttachmentUploader::Attachment.new(:file)
-  belongs_to :attachable, polymorphic: true, optional: true
-end
-
-# INFO: app/models/image.rb
-class Image < Attachment
-  include ImageUploader::Attachment.new(:file)
-end
-```
-
-- **Create Sidekiq Jobs**
-```ruby
-# INFO: app/jobs/attachemnt_upload.rb
-class AttachmentUploadJob
-  include Sidekiq::Worker
-  sidekiq_options queue: :"attachment:upload", retry: 3
-
-  def perform(data)
-    ActiveRecord::Base.uncached do
-      klass, id = data['record']
-      Shrine::Attacher.promote(data)
-    end
-  end
-end
-
-# INFO: app/jobs/attachemnt_delete.rb
-class AttachmentDeleteJob
-  include Sidekiq::Worker
-  sidekiq_options queue: :"attachment:delete", retry: false
-
-  def perform(data)
-    klass, id = data['record']
-    Shrine::Attacher.delete(data)
-  end
-end
-```
-
-- **Configure Sidekiq**
-```ruby
-# INFO:config/sidekiq.yml
----
-production:
-  :concurrency: 1
-development:
-  :concurrency: 1
-:queues:
-  - 'catalog:attachment:upload'
-  - 'catalog:attachment:delete'
-
-# INFO: config/initializers/redis.rb
-  Redis.current = Redis.new(host: 'redis', db: '1', port: 6379)
-
-# INFO: config/initializers/sidekiq.rb
-  Sidekiq.configure_server { |config| config.redis =  Redis.current }
-  Sidekiq.configure_client { |config| config.redis =  Redis.current }
-```
-
-- **Examples of using**
-```ruby
-  # INFO: app/models/product.rb
-  class Product < ApplicationRecord
-    has_many :images, as: :attachable, dependent: :destroy
-  end
-```
-
 - **Additional info:**
 [Shrine Docs](https://github.com/shrinerb/shrine/blob/master/README.md)
 [AzureStorageBlob Docs](https://github.com/Azure/azure-storage-ruby/blob/master/blob/README.md)
 
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/anerhan/shrine-storage. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/TQsoft-GmbH/shrine-storage-azureblob. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
@@ -216,4 +57,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Shrine::Storage project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/anerhan/shrine-storage/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Shrine::Storage project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/TQsoft-GmbH/shrine-storage-azureblob/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install shrine-storage
+    $ gem install shrine-storage-azureblob
 
 ## Usage
 
-- **Create file _config/initilizers/shine.rb_**
+- **Create file _config/initializers/shrine.rb_**
 ```ruby
 require 'shrine'
 require 'shrine/storage/redis'

--- a/lib/shrine/storage.rb
+++ b/lib/shrine/storage.rb
@@ -3,7 +3,7 @@
 require 'shrine/storage/version'
 require 'shrine/storage/azure_blob'
 
-module Shrine
+class Shrine
   module Storage
     class Error < StandardError; end
   end

--- a/lib/shrine/storage/azure_blob.rb
+++ b/lib/shrine/storage/azure_blob.rb
@@ -13,16 +13,16 @@ class Shrine
     class AzureBlob
       attr_reader :client, :account_name, :access_key, :container_name, :multipart_threshold, :public
 
-      def initialize(
-        account_name: nil, access_key: nil,
-        container_name: nil, multipart_threshold: {},
-        public: nil
-      )
+      def initialize(account_name: nil, access_key: nil, container_name: nil, multipart_threshold: {}, public: nil)
         @access_key = access_key
         @account_name = account_name
         @container_name = container_name
         @multipart_threshold = multipart_threshold
         @sas = Azure::Storage::Common::Core::Auth::SharedAccessSignature.new account_name, access_key
+        @client = Azure::Storage::Blob::BlobService.create(
+          storage_account_name: account_name,
+          storage_access_key: access_key
+        )
         @public = public
       end
 
@@ -47,48 +47,29 @@ class Shrine
 
       def open(id, _rewindable: false, **_options)
         GC.start
-
-        client = Azure::Storage::Blob::BlobService.create(
-          storage_account_name: account_name,
-          storage_access_key: access_key
-        )
-
-        _blob, content = client.get_blob(container_name, id)
+        _blob, content = @client.get_blob(container_name, id)
         StringIO.new(content)
       end
 
       def put(io, id, **_options)
-        client = Azure::Storage::Blob::BlobService.create(
-          storage_account_name: account_name,
-          storage_access_key: access_key
-        )
         if (path = extract_path(io))
           ::File.open(path, 'rb') do |file|
-            client.create_block_blob(container_name, id, file.read, timeout: 30)
+            @client.create_block_blob(container_name, id, file.read, timeout: 30, **_options)
           end
         else
-          client.create_block_blob(container_name, id, io.to_io)
+          @client.create_block_blob(container_name, id, io.to_io, **_options)
         end
       end
 
       def delete(id)
-        client = Azure::Storage::Blob::BlobService.create(
-          storage_account_name: account_name,
-          storage_access_key: access_key
-        )
-        client.delete_blob(container_name, id)
+        @client.delete_blob(container_name, id)
       end
-
 
       # :public
       # :  Returns the unsigned URL to the S3 object. This requires the S3
       #    object to be public.
       def url(id, public: self.public, **options)
-        client = Azure::Storage::Blob::BlobService.create(
-          storage_account_name: account_name,
-          storage_access_key: access_key
-        )
-        uri = client.generate_uri("#{container_name}/#{id}")
+        uri = @client.generate_uri("#{container_name}/#{id}")
         uri.scheme = options[:scheme] || 'https'
         unless public
           uri.query = @sas.generate_service_sas_token(

--- a/lib/shrine/storage/azure_blob.rb
+++ b/lib/shrine/storage/azure_blob.rb
@@ -11,16 +11,19 @@ require 'tempfile'
 class Shrine
   module Storage
     class AzureBlob
-      attr_reader :client, :account_name, :access_key, :container_name, :multipart_threshold
+      attr_reader :client, :account_name, :access_key, :container_name, :multipart_threshold, :public
 
       def initialize(
         account_name: nil, access_key: nil,
-        container_name: nil, multipart_threshold: {}
+        container_name: nil, multipart_threshold: {},
+        public: nil
       )
         @access_key = access_key
         @account_name = account_name
         @container_name = container_name
         @multipart_threshold = multipart_threshold
+        @sas = Azure::Storage::Common::Core::Auth::SharedAccessSignature.new account_name, access_key
+        @public = public
       end
 
       def upload(io, id, shrine_metadata: {}, **_upload_options)
@@ -76,17 +79,27 @@ class Shrine
         client.delete_blob(container_name, id)
       end
 
-      def url(id, **options)
+
+      # :public
+      # :  Returns the unsigned URL to the S3 object. This requires the S3
+      #    object to be public.
+      def url(id, public: self.public, **options)
         client = Azure::Storage::Blob::BlobService.create(
           storage_account_name: account_name,
           storage_access_key: access_key
         )
         uri = client.generate_uri("#{container_name}/#{id}")
-        if options[:scheme] == 'http'
-          uri.to_s.gsub('https:', 'http:')
-        else
-          uri.to_s
+        uri.scheme = options[:scheme] || 'https'
+        unless public
+          uri.query = @sas.generate_service_sas_token(
+            uri.path,
+            service: 'b', # blob
+            protocol: uri.scheme,
+            permissions: 'r', # read
+            **options # expiry: 30.minutes.from_now.to_s # as Time to string
+          )
         end
+        uri.to_s
       end
 
       class Tempfile < ::Tempfile

--- a/lib/shrine/storage/version.rb
+++ b/lib/shrine/storage/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Shrine
+class Shrine
   module Storage
-    VERSION = '0.1.2'
+    VERSION = '0.2.0'
   end
 end

--- a/shrine-storage-azureblob.gemspec
+++ b/shrine-storage-azureblob.gemspec
@@ -5,22 +5,22 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'shrine/storage/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'shrine-storage'
+  spec.name          = 'shrine-storage-azureblob'
   spec.version       = Shrine::Storage::VERSION
-  spec.authors       = ['Dmitriy Bielorusov', 'Syndicode LLC']
-  spec.email         = ['d.belorusov@gmail.com', 'info@syndicode.com']
+  spec.authors       = ['Ralf Vitasek', 'TQsoft GmbH', 'Dmitriy Bielorusov', 'Syndicode LLC']
+  spec.email         = ['info@tqsoft.de', 'd.belorusov@gmail.com', 'info@syndicode.com']
 
   spec.summary       = 'Extend existing shrine gem with using official azure-storage-blob SDK'
   spec.description   = 'Extend existing shrine gem with using official azure-storage-blob SDK'
-  spec.homepage      = 'https://github.com/Syndicode/shrine-storage.git'
+  spec.homepage      = 'https://github.com/TQsoft-GmbH/shrine-storage-azureblob'
   spec.license       = 'MIT'
 
   if spec.respond_to?(:metadata)
     # spec.metadata['allowed_push_host'] = ''
 
     spec.metadata['homepage_uri'] = spec.homepage
-    spec.metadata['source_code_uri'] = 'https://github.com/Syndicode/azure-storage.git'
-    spec.metadata['changelog_uri'] = 'https://github.com/Syndicode/azure-storage.git'
+    spec.metadata['source_code_uri'] = 'https://github.com/TQsoft-GmbH/shrine-storage-azureblob'
+    spec.metadata['changelog_uri'] = 'https://github.com/TQsoft-GmbH/shrine-storage-azureblob'
   else
     raise 'RubyGems 2.0 or newer is required to protect against ' \
       'public gem pushes.'
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 2.0.2'
@@ -41,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_dependency 'azure-storage-blob', '~> 1.1.0'
-  spec.add_dependency 'nokogiri', '>= 1.10.8'
+  spec.add_dependency "shrine"
+  spec.add_dependency 'nokogiri', '>= 1.10.9'
+  spec.add_dependency 'azure-storage-blob', '~> 2.0.0'
 end


### PR DESCRIPTION
Refactoring azure storage for shrine

- fix typo in version that broke everything
- fix mime_type (always deaulted to text/plain)
- update to Azure Storage gem 2.0 (with SAS signing support)
- add public switch for Storage options
- support SAS presigned URLs so it's not required to use public readable containers